### PR TITLE
Hugo versions mac&linux + fsm3 post format bug fix

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -16,7 +16,7 @@ defaultContentLanguageInSubdir = false
 # Useful when translating.
 enableMissingTranslationPlaceholders = true
 
-disableKinds = ["taxonomy", "taxonomyTerm"]
+disableKinds = ["taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true
@@ -54,7 +54,7 @@ anchor = "smart"
 [languages]
 [languages.en]
 title = "Findy Agency"
-description = "Findy Agency documentation"
+#description = "Findy Agency documentation"
 languageName ="English"
 # Weight used for sorting.
 weight = 1

--- a/config.toml
+++ b/config.toml
@@ -17,6 +17,7 @@ defaultContentLanguageInSubdir = false
 enableMissingTranslationPlaceholders = true
 
 disableKinds = ["taxonomy"]
+ignoreErrors = ["error-disable-taxonomy"]
 
 # Highlighting config
 pygmentsCodeFences = true

--- a/content/en/blog/fsm3/index.md
+++ b/content/en/blog/fsm3/index.md
@@ -22,6 +22,7 @@ Let’s start with the result and see what the state machine looks like. As you
 can see below, it’s simple, elegant, and, most importantly, easy to reason.
 
 <img src="/blog/2024/04/11/issuing-chatbot/fsm.svg" width="1900"/>
+
 *Issuing Service Chatbot*
 <br/><br/>
 


### PR DESCRIPTION
- **rm hugo warning on v0.124.1-..**
- **fix non-italic issue with firts image caption**
- **ignore taxonomy error in v0.110.0..**
